### PR TITLE
Use 'shift' keycode instead of numeric code

### DIFF
--- a/shared/helpers/macos/KeyCode.js
+++ b/shared/helpers/macos/KeyCode.js
@@ -61,7 +61,14 @@ exports.KeyCode = {
   backspace: 51,
   escape: 53,
   command: 55,
+
+  /**
+   * The keycode for shift (57) has been found to be non-functional when
+   * applied in conjunction with "tab" in macOS 13 and 14.
+   * https://github.com/bocoup/at-driver-servers/pull/11
+   */
   shift: 'shift',
+
   option: 58,
   control: 59,
   fn: 63,

--- a/test/helpers/macos/applescript.js
+++ b/test/helpers/macos/applescript.js
@@ -88,11 +88,11 @@ suite('helpers/macos/applescript', () => {
             '    tell application "System Events"\n' +
             '        key down 55\n' +
             '        key down 58\n' +
-            '        key down 57\n' +
+            '        key down shift\n' +
             '        key down 11\n' +
             '        \n' +
             '        key up 11\n' +
-            '        key up 57\n' +
+            '        key up shift\n' +
             '        key up 58\n' +
             '        key up 55\n' +
             '    end tell\n' +


### PR DESCRIPTION
This is a partial fix for a [bug](https://github.com/w3c/aria-at-app/issues/1159) that affected the ability to navigate backwards through a document using SHIFT+TAB keys on MacOS.

The ability to navigate backwards using "Single-Key Quick Nav" (which also uses the SHIFT key) is still broken. I would recommend that we merge this partial fix, add some regression testing for our applescript output, and then come back to the Single-Key Quick Nav issue once some more reliable testing is in place for our applescript generators.  