### PR TITLE
Revamp installation

### DIFF
--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -5,8 +5,14 @@ const installation = require('../installation');
 module.exports = /** @type {import('yargs').CommandModule} */ ({
   command: 'uninstall',
   describe: 'Uninstall text to speech extension and other support',
-  async handler() {
-    await installation.uninstall();
+  builder(yargs) {
+    return yargs.option('when-many', {
+      desc: 'How to respond when more than one instance of the extension is present (the default behavior is to fail)',
+      choices: ['local', 'all'],
+    });
+  },
+  async handler({ whenMany }) {
+    await installation.uninstall({ whenMany });
 
     console.log('Uninstallation completed successfully.');
   },

--- a/lib/installation.js
+++ b/lib/installation.js
@@ -25,6 +25,17 @@ const SYSTEM_VOICE_IDENTIFIER = 'com.apple.Fred';
  * - src/MacOSATDriverServer/MacOSATDriverServerExtension/Info.plist
  */
 const PLUGIN_TRIPLET_IDENTIFIER = 'ausp atdg BOCU';
+/**
+ * From pluginkit(8):
+ *
+ * > All matching plug-ins are returned, one per line. Each line may begin with any one of the following tags indicating the user election state:
+ * >     + indicates that the user has elected to use the plug-in
+ * >     - indicates that the user has elected to ignore the plug-in
+ * >     ! indicates that the user has elected to use the plug-in for debugger use
+ * >     = indicates that the plug-in is superseded by another plug-in
+ * >     ? unknown user election state
+ */
+const pluginkitFirstElementPattern = /^[+!=?-]?\s*([^\s(]+)\((.+)\)$/;
 
 /**
  * Execute the "exec" method from the built-in `child_process` module. In the
@@ -102,7 +113,11 @@ exports.install = async function ({ unattended }) {
     }
   }
 
-  if (await isInstalled()) {
+  const plugins = await listPlugins();
+
+  debug(`Found ${plugins.length} plugin(s)`);
+
+  if (plugins.length) {
     return console.log('Already installed.');
   }
 
@@ -114,17 +129,59 @@ exports.install = async function ({ unattended }) {
 };
 
 /**
+ * Uninstall the driver. Since installations occupy space in a global registry,
+ * the installation status may be complicated by the presence of prior
+ * releases. The `whenMany` parameter (exposed to end users via the
+ * `--when-many` command-line argument) attempts to assist recovery from such
+ * states.
+ *
+ * @param {object} options
+ * @param {"local"|"all"} [options.whenMany] - Whether (and how) to tolerate
+ *                                             the case that more than one
+ *                                             version of the plugin is present
+ *                                             on the system.
  * @returns {Promise<void>}
  */
-exports.uninstall = async function () {
+exports.uninstall = async function ({ whenMany }) {
   const options = await getExecOptions();
+  const plugins = await listPlugins();
 
-  if (!(await isInstalled())) {
+  debug(`Found ${plugins.length} plugin(s)`);
+
+  if (!plugins.length) {
     throw new Error('Not installed');
   }
 
+  if (plugins.length > 1 && !whenMany) {
+    throw new Error(
+      `Found ${plugins.length} installations. Use the \`--when-many\` ` +
+        `argument to handle this condition.`,
+    );
+  }
+
+  let toUninstall;
+
+  if (whenMany === 'local') {
+    toUninstall = plugins.filter(plugin => plugin.location.startsWith(options.cwd.toString()));
+    if (!toUninstall.length) {
+      throw new Error('Local installation not found.');
+    }
+  } else {
+    toUninstall = plugins;
+  }
+
   await setSystemVoice(SYSTEM_VOICE_IDENTIFIER);
-  await unregisterExtensions(options);
+
+  for (const plugin of plugins) {
+    const parts = plugin.location.split(APPLICATION_NAME);
+    if (parts.length !== 2) {
+      throw new Error(`Unsupported installation path: '${plugin.location}'`);
+    }
+
+    await unregisterExtensions({ cwd: parts[0] });
+  }
+
+  return;
 };
 
 /**
@@ -142,19 +199,56 @@ const canPressKeys = async () => {
   return true;
 };
 
-const isInstalled = async function () {
-  let stdout;
+/**
+ * The output of `pluginkit` is poorly-documented, so this function parses that
+ * output strictly according to the apparent structure as of July 2026. It is
+ * intended to fail in the presence of any changes to the structure because in
+ * the absence of a formal contract, such changes could reflect any number of
+ * incompatibilities that should be reviewed by a maintainer.
+ *
+ */
+const listAllPlugins = async function () {
+  const { stdout } = await exec('pluginkit -mvAD');
 
-  try {
-    ({ stdout } = await exec(`auval -v ${PLUGIN_TRIPLET_IDENTIFIER}`));
-  } catch (error) {
-    if (error.stdout && error.stdout.includes("didn't find the component")) {
-      return false;
-    }
-    throw error;
-  }
+  return Promise.all(
+    stdout
+      .split('\n')
+      // Ignore empty lines
+      .filter(line => !!line)
+      // Ignore final line of output
+      .filter(line => !/^\s*\(\d+ plug-ins\)$/.test(line))
+      .map(async line => {
+        const [firstElement, uuid, date, location, ...rest] = line.split('\t');
 
-  return /MacOSATDriverServerExtension/.test(stdout);
+        if (rest.length) {
+          throw new TypeError(`Encountered unexpected trailing output: "${line}"`);
+        }
+        const match = pluginkitFirstElementPattern.exec(firstElement);
+
+        if (!match) {
+          throw new TypeError(`Encountered unexpected identifier: "${line}"`);
+        }
+        const [, identifier, version] = match;
+
+        if (!(await fs.stat(location)).isDirectory()) {
+          throw new TypeError(`Encountered non-existent directory: "${line}"`);
+        }
+
+        return { identifier, version, uuid, date, location };
+      }),
+  );
+};
+
+/**
+ * Export the function so it can be executed in the project's test suite. While
+ * the set of available plugins is system-dependent, simply invoking the
+ * function will help to surface new incompatibilities in future release of
+ * macOS.
+ */
+exports._listAllPlugins = listAllPlugins;
+
+const listPlugins = async function () {
+  return (await listAllPlugins()).filter(({ identifier }) => identifier === EXTENSION_IDENTIFIER);
 };
 
 /**
@@ -162,7 +256,7 @@ const isInstalled = async function () {
  */
 const getExecOptions = async function () {
   return {
-    cwd: resolve(__dirname, '../../MacOSATDriverServer/Build/Debug'),
+    cwd: resolve(__dirname, '../src/MacOSATDriverServer/Build/Debug'),
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test-macos-key-press": "mocha --ui tdd --timeout 5000 test/test-macos-key-press.js",
     "test-style": "prettier --check lib test",
     "test-types": "tsc -p tsconfig.json",
-    "test-unit": "mocha --ui tdd --timeout 5000 test/test.js test/helpers/**/*.js"
+    "test-unit": "mocha --ui tdd --timeout 5000 test/test.js test/test-plugin-enumeration.js test/helpers/**/*.js"
   },
   "author": "Bocoup",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.3",
   "description": "A WebSocket server which allows clients to observe the text enunciated by a screen reader and to simulate user input using macOS",
   "scripts": {
+    "prepare": "./scripts/prepare.js",
     "prettier": "prettier --write lib test",
     "test": "npm run test-style && npm run test-types && npm run test-unit",
     "test-macos-key-press": "mocha --ui tdd --timeout 5000 test/test-macos-key-press.js",
@@ -16,7 +17,7 @@
     "at-driver": "./lib/bin/at-driver"
   },
   "files": [
-    "MacOSATDriverServer/Build/debug",
+    "src/MacOSATDriverServer/Build/Debug",
     "README.md",
     "lib"
   ],

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Verify that the expected machine-generated assets are present in the local
+ * directory. This script is intended to be executed prior to packaging the
+ * project via the "prepare" npm life cycle script as a guard against invalid
+ * releases.
+ */
+
+const assert = require('assert');
+const fs = require('fs/promises');
+const path = require('path');
+
+const buildDir = path.resolve(
+  __dirname, '..', 'src/MacOSATDriverServer/Build/Debug'
+);
+
+(async () => {
+  assert(
+    (await fs.stat(buildDir)).isDirectory(),
+    `Expected directory '${buildDir}' to exist`
+  );
+})();

--- a/test/test-plugin-enumeration.js
+++ b/test/test-plugin-enumeration.js
@@ -1,0 +1,23 @@
+'use strict';
+const assert = require('assert');
+
+const { _listAllPlugins } = require('../lib/installation');
+
+suite('_listAllPlugins', () => {
+  test('validity of enumeration', async () => {
+    const plugins = await _listAllPlugins();
+
+    assert(plugins.length > 0, 'Identifies at least one plugin');
+
+    for (let idx = 0; idx < plugins.length; idx += 1) {
+      const plugin = plugins[idx];
+      const idString = `(plugin #${idx} of ${plugins.length})`;
+
+      assert.equal(typeof plugin.identifier, 'string', `identifier ${idString}`);
+      assert.equal(typeof plugin.version, 'string', `version ${idString}`);
+      assert.equal(typeof plugin.uuid, 'string', `uuid ${idString}`);
+      assert.equal(typeof plugin.date, 'string', `date ${idString}`);
+      assert.equal(typeof plugin.location, 'string', `location ${idString}`);
+    }
+  });
+});


### PR DESCRIPTION
This patch corrects a pathing error which interfered with installation and uninstallation. It also enhances installation and uninstallation to recognize (and optionally recover from) environments with multiple parallel installations. Finally, it adds a guard to prevent mistakes like [the one we made when publishing version 0.1.3](https://github.com/bocoup/macos-at-driver-server/issues/32#issuecomment-4662489066)

/cc @lolaodelola @ChrisC